### PR TITLE
Add more verbose IMU connection failure message

### DIFF
--- a/teensy/firmware/src/firmware.ino
+++ b/teensy/firmware/src/firmware.ino
@@ -118,6 +118,17 @@ void loop()
         {
             imu_is_initialized = initIMU();
 
+            char buffer[50];
+            sprintf(buffer, "=== ACCELEROMETER === %d", accelerometer.testConnection());
+            nh.loginfo(buffer);
+
+            sprintf(buffer, "=== GYROSCOPE === %d", gyroscope.testConnection());
+            nh.loginfo(buffer);
+
+            sprintf(buffer, "=== MAGNETOMETER === %d", magnetometer.testConnection());
+            nh.loginfo(buffer);
+
+
             if(imu_is_initialized)
                 nh.loginfo("IMU Initialized");
             else


### PR DESCRIPTION
I noticed this helps a lot to pinpoint exactly what's breaking when your IMU fails to connect.